### PR TITLE
Enable attestations for PyPI action

### DIFF
--- a/.github/workflows/python-publish-pypi.yaml
+++ b/.github/workflows/python-publish-pypi.yaml
@@ -49,5 +49,6 @@ jobs:
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@8a08d616893759ef8e1aa1f2785787c0b97e20d6 # v1.10.0
       with:
+          attestations: true
           verbose: true
           print-hash: true


### PR DESCRIPTION
ref: https://github.com/pypa/gh-action-pypi-publish#generating-and-uploading-attestations